### PR TITLE
Update water function

### DIFF
--- a/EWS/EWS.ino
+++ b/EWS/EWS.ino
@@ -52,7 +52,7 @@ bool wifiFailed = false;
 bool wifiConnected = false;
 
 volatile byte buttonPressed = false;
-bool waterON = false;
+volatile bool waterON = false;
 bool waterPreviousState = false;
 unsigned long serialTimeout = 1000;
 const unsigned long waterCutoffTime = 2 * 60000; //set to 2mins initially
@@ -72,6 +72,12 @@ millisDelay MQTTCheckTimer;
 
 FlowSensor Sensor(type, flowSensorPin);
 
+enum waterModes{
+  turnWaterOn,
+  turnWaterOff,
+  toggleWaterState,
+  waterNone
+};
 
 void setup()
 {
@@ -216,38 +222,37 @@ void flowCount()
 
 void loop()
 {
-  //  if (buttonPressed) {
-  //   Serial.println("Button Pressed");
-  //   buttonPressed = false;
-  //   waterON = !waterON;
-  //  }
-   mqttClient.poll();
-  //  waterToggle();
-   flowFunction();
-   heartbeatMQTT();
+  mqttClient.poll();
+  waterCheck(waterNone);
+  flowFunction();
+  heartbeatMQTT();
 }
 
 void handleButtonPress()
 {
+  // In this function we handle if the button has been pressed. 
+  // We use a debounce timer to stop the button being triggered multiple times in a short period
+  // Water State is toggle and we call valve control to immediately turn the water on or off
+  // All other water check fucntions like send MQTT updates are handled by the waterCheck function in the main loop
   if (millis() - buttonBounceTime > BOUNCE_DURATION)  
   {
-    // buttonPressed = true; 
-    waterToggle("TOGGLE");
+    waterON = !waterON;
+    valveControl();
     buttonBounceTime = millis();
   }
 }
 
-void waterToggle(String waterState)
+void waterCheck(waterModes waterState)
 {
-  if (waterState = "TOGGLE")
+  if (waterState == toggleWaterState)
   {
     waterON = !waterON;
   }
-  else if (waterState = "ON")
+  else if (waterState == turnWaterOn)
   {
     waterON = true;
   }
-  else if (waterState = "OFF")
+  else if (waterState == turnWaterOff)
   {
     waterON = false;
   }
@@ -255,6 +260,14 @@ void waterToggle(String waterState)
   if (waterPreviousState != waterON)
   {
     buttonBounceTime = millis(); //stop the button triggering on strange power scenarios
+    valveControl();
+    MQTTSend(topicState, waterON ? "ON" : "OFF");
+    waterPreviousState = waterON;
+  }
+}
+
+void valveControl()
+{
     if(waterON)
     {
       digitalWrite(relayPin, HIGH);
@@ -265,10 +278,9 @@ void waterToggle(String waterState)
       digitalWrite(relayPin, LOW);
       digitalWrite(ledPin, LOW);
     }
-    MQTTSend(topicState, waterON ? "ON" : "OFF");
-    waterPreviousState = waterON;
-  }
 }
+
+
 
 void flowFunction()
 {
@@ -297,7 +309,6 @@ void flowFunction()
     }
     else {
       Serial.println("Water Off");
-      // lcd.send_string("W Off                              ");
       lcd.send_string(charLCD16("W Off").c_str());
     }
     lcd.setCursor(0,1);
@@ -319,8 +330,7 @@ void flowFunction()
 
   if (flowRunTimer.justFinished())
     {
-      // waterON = false;
-      waterToggle("OFF");
+      waterCheck(turnWaterOff);
     }
 
 }
@@ -355,14 +365,12 @@ void onMqttMessage(int messageSize)
       if(strcmp(message,"ON") == 0)
       {
         Serial.println("Turing Water on");
-        // waterON = true;
-        waterToggle("ON");
+        waterCheck(turnWaterOn);
       }
       else if(strcmp(message,"OFF") == 0)
       {
         Serial.println("Turing Water off");
-        // waterON = false;
-        waterToggle("OFF");
+        waterCheck(turnWaterOff);
       }
     }
 

--- a/EWS/EWS.ino
+++ b/EWS/EWS.ino
@@ -53,7 +53,7 @@ bool wifiConnected = false;
 
 volatile byte buttonPressed = false;
 bool waterON = false;
-bool waterPreviouseState = false;
+bool waterPreviousState = false;
 unsigned long serialTimeout = 1000;
 const unsigned long waterCutoffTime = 2 * 60000; //set to 2mins initially
 const unsigned long flowReadTime = 1000; //read the flow reade once a second
@@ -216,13 +216,13 @@ void flowCount()
 
 void loop()
 {
-   if (buttonPressed) {
-    Serial.println("Button Pressed");
-    buttonPressed = false;
-    waterON = !waterON;
-   }
+  //  if (buttonPressed) {
+  //   Serial.println("Button Pressed");
+  //   buttonPressed = false;
+  //   waterON = !waterON;
+  //  }
    mqttClient.poll();
-   waterToggle();
+  //  waterToggle();
    flowFunction();
    heartbeatMQTT();
 }
@@ -231,16 +231,30 @@ void handleButtonPress()
 {
   if (millis() - buttonBounceTime > BOUNCE_DURATION)  
   {
-    buttonPressed = true; 
+    // buttonPressed = true; 
+    waterToggle("TOGGLE");
     buttonBounceTime = millis();
   }
 }
 
-void waterToggle()
+void waterToggle(String waterState)
 {
-  if (waterPreviouseState != waterON)
+  if (waterState = "TOGGLE")
   {
-    buttonBounceTime = millis(); //stop the button triggering on strange power senarios
+    waterON = !waterON;
+  }
+  else if (waterState = "ON")
+  {
+    waterON = true;
+  }
+  else if (waterState = "OFF")
+  {
+    waterON = false;
+  }
+
+  if (waterPreviousState != waterON)
+  {
+    buttonBounceTime = millis(); //stop the button triggering on strange power scenarios
     if(waterON)
     {
       digitalWrite(relayPin, HIGH);
@@ -252,7 +266,7 @@ void waterToggle()
       digitalWrite(ledPin, LOW);
     }
     MQTTSend(topicState, waterON ? "ON" : "OFF");
-    waterPreviouseState = waterON;
+    waterPreviousState = waterON;
   }
 }
 
@@ -305,8 +319,8 @@ void flowFunction()
 
   if (flowRunTimer.justFinished())
     {
-      waterON = false;
-      waterToggle();
+      // waterON = false;
+      waterToggle("OFF");
     }
 
 }
@@ -335,25 +349,20 @@ void onMqttMessage(int messageSize)
     mqttClient.readBytes(message, messageSize);
     message[messageSize] = '\0'; // Null-terminate the char array
 
-    // while (mqttClient.available())
-    // {   
-    //     message = (char)mqttClient.readBytes()();
-    //     Serial.print(message);
-    // }
-    // Serial.print("Message: ");
-    // Serial.println(message);
 
     if (topic == topicSet)
     {
       if(strcmp(message,"ON") == 0)
       {
         Serial.println("Turing Water on");
-        waterON = true;
+        // waterON = true;
+        waterToggle("ON");
       }
       else if(strcmp(message,"OFF") == 0)
       {
         Serial.println("Turing Water off");
-        waterON = false;
+        // waterON = false;
+        waterToggle("OFF");
       }
     }
 


### PR DESCRIPTION
Updated the core water toggle method.
Now when the button is pressed the valve and led are toggled Immediately, other functions like sending the will wait until the main loop reaches them. 
Also, updated other functions that change the valve state to call the waterCheck immediately rather than waiting for the loop to reach the check. 

This method was not used with the button interrupt as it led to system instability. Recommendations I have seen online state the interrupt function should be kept as short as possible to avoid things like calls to the serial output this method has been implemented so the valve is operated in real time when the button is pressed, but the messaging and notification wait until the loop reaches the waterCheck. 